### PR TITLE
 added fingerprint values for 2020 base clarity

### DIFF
--- a/selfdrive/car/honda/values.py
+++ b/selfdrive/car/honda/values.py
@@ -1310,12 +1310,14 @@ FW_VERSIONS = {
     ],
     (Ecu.srs, 0x18da53f1, None): [
         b'77959-TRW-A210\x00\x00',
+        b'77959-TRW-A220\x00\x00',
     ],
     (Ecu.gateway, 0x18daeff1, None): [
         b'38897-TRW-A010\x00\x00',
     ],
     (Ecu.combinationMeter, 0x18da60f1, None): [
         b'78109-TRW-A020\x00\x00',
+        b'78109-TRW-A030\x00\x00',
     ],
   },
 }


### PR DESCRIPTION
I was still having fingerprint issues with my 2020 Clarity until I added these two firmware versions. Seems like there has been some firmware updates for these cars!